### PR TITLE
firefox is weird

### DIFF
--- a/src/components/FrameCustomiser.svelte
+++ b/src/components/FrameCustomiser.svelte
@@ -176,4 +176,8 @@
     .did-copy {
         color: green;
     }
+    
+    iframe {
+        width: -moz-available;
+    }
 </style>


### PR DESCRIPTION
Firefox is rendering the iframe with scrollbars for me, this seems to fix it.

<img height="160" alt="Screenshot 2023-05-13 at 1 57 52 pm" src="https://github.com/Vendicated/DiscordWidgets/assets/87679354/29e41a48-dd64-43f0-85b1-68a7718c8a40">
<img height="160" alt="Screenshot 2023-05-13 at 1 58 11 pm" src="https://github.com/Vendicated/DiscordWidgets/assets/87679354/6ccc0587-a4f4-40a0-9c70-e79c5228356f">
