### PR TITLE
Use lossless quality for user banner and user avatar

### DIFF
--- a/src/discord_api.ts
+++ b/src/discord_api.ts
@@ -72,12 +72,12 @@ export function getUserAvatar(user: User, format?: "webp" | "png") {
         return `${CDN_BASE}/embed/avatars/${n}.png`;
     }
 
-    return `${CDN_BASE}/avatars/${user.id}/${user.avatar}.${format ?? getExt(user.avatar)}?size=256`;
+    return `${CDN_BASE}/avatars/${user.id}/${user.avatar}.${format ?? getExt(user.avatar)}?size=256&quality=lossless`;
 }
 
 export function getUserBanner(user: User) {
     if (!user.banner) return null;
-    return `${CDN_BASE}/banners/${user.id}/${user.banner}.${getExt(user.banner)}?size=512`;
+    return `${CDN_BASE}/banners/${user.id}/${user.banner}.${getExt(user.banner)}?size=512&quality=lossless`;
 }
 
 export function getUserFlags(user: User, guessNitro: boolean): string[] {


### PR DESCRIPTION
Noticed a little pixellation on my banner in the widget today, so I decided to make this PR
All this does is appends &quality=lossless to the URLs of the banner and avatar from the CDN.