### PR TITLE
missing quotation marks for height of iframe

### DIFF
--- a/src/components/FrameCustomiser.svelte
+++ b/src/components/FrameCustomiser.svelte
@@ -150,7 +150,7 @@
         <iframe
             title="Discord user embed"
             width="340"
-            height=${height}
+            height="${height}"
             frameborder="0"
             sandbox="allow-scripts"
             src="${fullUrl}"


### PR DESCRIPTION
When i tried it on the live-version, it gave me errors atleast, maybe its just a me-issue i dont know
![Screenshot_20241204_121957](https://github.com/user-attachments/assets/97696c87-53c7-43c4-827f-79615bca7c57)

Love your tool though, ty for your work!